### PR TITLE
linux support!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,31 @@
 os:
   - osx
-sudo: false
+  - linux
+
 language: rust
+sudo: required
+
 rust:
   # - nightly
   # - beta
   - stable
+
 before_install:
-  - brew update
-  - brew install openal-soft libsndfile
-before_script:
   - |
-    pip install 'travis-cargo<0.2' --user &&
-    export PATH=$HOME/.local/bin:$PATH
+    ### Target dependent setup
+
+    # OSX
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+       brew update
+       brew uninstall libjpeg libpng libtiff --ignore-dependencies || true
+       brew install openal-soft libsndfile
+    fi
+
+    # Linux
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        sudo apt-get update
+        sudo apt-get install -y libopenal-dev libsndfile1-dev
+    fi
+
 script:
-  - |
-    cargo build
-    cargo test
+  - cargo build

--- a/README.md
+++ b/README.md
@@ -1,25 +1,41 @@
 # modelm
 [![Build Status](https://travis-ci.org/millerjs/modelm.svg?branch=master)](https://travis-ci.org/millerjs/modelm)
 
-A OSX **Mechanical keyboard audio simulator** for your Mac keyboard written in [Rust](https://www.rust-lang.org/).
+A **Mechanical keyboard audio simulator** for your keyboard written in [Rust](https://www.rust-lang.org/).
 
 > *Get yourself clickity-clacking.*
 
 Inspired by the [IBM Model M Keyboard](https://en.wikipedia.org/wiki/Model_M_keyboard) and a disproportionate love of clicky keyboards over non clicky keyboards, this is a simple program to simulate the Model M by providing audible keystroke feedback.
 
-For a linux clone, see [modelm-linux](https://github.com/mlsteele/modelm-linux).
-
 ## Features
-To provide audible feedback for your keystrokes, `modelm` hooks into OSX Quartz Events and must be run as `root` OR from a terminal with accessibility features enabled.
+To provide audible feedback for your keystrokes, `modelm` hooks into OSX Quartz Events (on OSX) or your `/dev/input` keyboard device and must be run as `root`(or from a terminal with accessibility features enabled on OSX).
 
 * **Stereo sounds** - Keys on the left sound like keys on the left. Keys on the right sound like Keys on the right.
-* **Customizable resource loading** - You can pick your favorite clickity-clacks.  Just point `modelm` to a directory with sound bites and a config file.
+* **Custom resource loading** - You can pick your favorite clickity-clacks.  Just point `modelm` to a directory with sound bites and a config file.
 
 ## Requirements
 
 Install OpenAL audio dependency.
+
+### OSX
+
 ```bash
+brew update
 brew install openal-soft libsndfile
+```
+### Debian/Ubuntu
+
+```bash
+apt-get update
+apt-get install libopenal-dev libsndfile1-dev
+```
+
+### Arch
+
+You may also need pulseaudio as shown
+
+```bash
+pacman -S openal libsndfile pulseaudio-alsa
 ```
 
 ## Installation
@@ -27,11 +43,23 @@ brew install openal-soft libsndfile
 
 ### Running a pre-compiled binary
 
-To run the compile binary, download the tar [here](https://github.com/millerjs/modelm/releases/download/v0.3.0/modelm_v0.3.0.tar.gz),
+To run the compiled
+binary,
+[download the latest release](https://github.com/millerjs/modelm/releases/latest) and
+simply run the following from within the extracted tarball
+
 ```bash
-tar -zxf modelm_v0.3.0.tar.gz
-cd modelm_v0.3.0
 ./modelm -d resources/modelm
+```
+
+### Installation from source
+
+First, install [Rust](https://github.com/rust-lang/rustup) and [Cargo](https://crates.io/).
+
+```
+git clone https://github.com/millerjs/modelm.git
+cd modelm
+cargo run --release
 ```
 
 ### Usage
@@ -46,9 +74,16 @@ sudo ./modelm -x 5.0
 # Or less dramatic
 sudo ./modelm -x 0.5
 
-# Or reverse because you have your headphones on backward
+# Or reverse because you have your headphones on backward, silly
 sudo ./modelm -x'-1'
 ```
+
+#### Note: Linux usage
+
+Currently, `modelm` defaults to reading from `/dev/input/event0`, but
+you can specify which event device to read at runtimefrom by setting the
+`MODELM_INPUT_DEVICE` environment variable to a new path.
+
 
 #### Help output
 
@@ -97,21 +132,11 @@ switches:
        - up_2.wav
 ```
 
-### Installation from source
-
-First, install [Rust](https://github.com/rust-lang/rustup) and [Cargo](https://crates.io/).
-
-```
-git clone https://github.com/millerjs/modelm.git
-cd modelm
-cargo run
-```
-
 ### Options
 
 You can pass options through cargo with a `--`, e.g. to change the volume:
 ```
-sudo cargo run -- -V 0.5
+sudo cargo run --release -- -V 0.5
 ```
 
 ### Credits

--- a/src/ffi/linux.rs
+++ b/src/ffi/linux.rs
@@ -1,0 +1,95 @@
+/// Linux key handler ffi
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::sync::mpsc::Sender;
+use std::{mem, slice, io, env};
+use super::types::{EventType, KeyEvent};
+
+type LinuxEventCode = u16;
+type LinuxEventType = u16;
+type LinuxEventValue = u32;
+type LinuxKernelTime = u64;
+
+#[repr(C)]
+#[derive(Debug)]
+struct TimeValue {
+   	__kernel_time_t: LinuxKernelTime,
+	__kernel_suseconds_t: LinuxKernelTime,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct InputEvent {
+	time: TimeValue,
+	etype: LinuxEventType,
+	code: LinuxEventCode,
+    value: LinuxEventValue,
+}
+
+/// Returns true if the code is considered a "flag", i.e. a modifier
+/// key
+fn is_flag(code: LinuxEventCode) -> bool {
+    match code {
+        100 | 125 | 29 | 42 | 54 | 56 | 58 | 97 => true,
+        _ => false,
+    }
+}
+
+
+impl Into<KeyEvent> for InputEvent {
+    fn into(self) -> KeyEvent {
+        KeyEvent {
+            code: self.code,
+            etype: match is_flag(self.code) {
+                true => EventType::FlagsChanged,
+                false => match self.value {
+                    0 => EventType::KeyUp,
+                    _ => EventType::KeyDown,
+                },
+            },
+        }
+    }
+}
+
+
+/// Reads event struct from input device
+fn read_event(device: &mut File) -> Result<InputEvent, io::Error> {
+    let mut event: InputEvent = unsafe { mem::zeroed() };
+    let event_size = mem::size_of::<InputEvent>();
+
+    unsafe {
+        try!(device.read_exact(slice::from_raw_parts_mut(
+            &mut event as *mut _ as *mut u8,
+            event_size
+        )));
+    }
+
+    if  event.etype != 1 {
+        return read_event(device);
+    }
+
+    debug!("read input event {:?}", event);
+    Ok(event)
+}
+
+
+/// Opens the input device, will use MODELM_INPUT_DEVICE environment
+/// variable if set
+fn open_device() -> Result<File, io::Error> {
+    let path = env::var("MODELM_INPUT_DEVICE")
+        .unwrap_or("/dev/input/event0".to_owned());
+    File::open(path)
+}
+
+
+/// Sends KeyEvents to the channel. Returns only on error.
+pub fn start_listener(channel: &Sender<KeyEvent>) {
+    let mut device = open_device().expect("unable to open device");
+
+    loop {
+        let _ = read_event(&mut device)
+            .map(|event| channel.send(event.into()))
+            .map_err(|err| error!("Unable to parse event, {:}", err));
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,0 +1,36 @@
+/// Target OS dependent ffi
+
+pub mod types;
+
+use std::sync::mpsc::Sender;
+use self::types::KeyEvent;
+
+// ======================================================================
+// Import module according to target os
+
+#[cfg(target_os = "macos")]
+mod osx;
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+// ======================================================================
+// Compile against os ffi module
+
+#[cfg(target_os = "macos")]
+pub fn register_listener(tx: &Sender<KeyEvent>) {
+    self::osx::register_listener(tx);
+}
+
+#[cfg(target_os = "linux")]
+pub fn register_listener(_: &Sender<KeyEvent>) {}
+
+
+/// Start listener should never return
+#[allow(unused_variables)]
+pub fn start_listener(tx: &Sender<KeyEvent>) {
+    #[cfg(target_os = "macos")]
+    self::osx::start_listener();
+    #[cfg(target_os = "linux")]
+    self::linux::start_listener(tx)
+}

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -1,0 +1,18 @@
+/// Define types to be passed between os and modelm
+
+pub type KeyCode = u16;
+
+#[derive(Debug)]
+#[repr(C)]
+pub enum EventType {
+    KeyDown,
+    KeyUp,
+    FlagsChanged,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct KeyEvent {
+    pub etype: EventType,
+    pub code: KeyCode,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-//! Small OSX commandline app that uses your keyboard to
-//! emulate mechanical keyboard audio.
+//! Small commandline app that uses your keyboard to emulate
+//! mechanical keyboard audio.
 
 #[macro_use]
 extern crate log;
@@ -34,9 +34,8 @@ pub fn setup_logging(matches: &ArgMatches)
     debug!("Set log level to {}", log_level);
 }
 
-
-fn main() -> () {
-    ears::init();
+fn main() {
+    assert!(ears::init());
 
     let matches = App::new("modelm")
         .version("0.2.0")
@@ -111,4 +110,5 @@ fn main() -> () {
         Ok(mut keyboard) => keyboard.listen(),
         Err(error) => error!("Unable to initialize keyboard: {:?}", error),
     };
+
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -6,7 +6,7 @@
 use rand;
 use ears::AudioController;
 use ears::Sound;
-use ffi::{KeyEvent, KeyCode, EventType};
+use ffi::types::{KeyEvent, KeyCode, EventType};
 use regex::Regex;
 use rand::distributions::IndependentSample;
 use rand::distributions::Range;
@@ -15,6 +15,10 @@ use std::path::Path;
 use yaml_rust;
 use yaml_rust::Yaml;
 use ::errors::KeyboardError;
+
+#[cfg(target_os = "macos")] const MIDDLE: f32 = 25.0;
+#[cfg(target_os = "linux")] const MIDDLE: f32 = 50.0;
+
 
 pub struct SwitchSound {
     sound: Sound,
@@ -95,7 +99,7 @@ impl Switch {
     }
 
     pub fn handle_event(&mut self, event: KeyEvent, options: &KeyboardOptions) {
-        let position = - (25.0 - event.code as f32) * options.x_scale / 300.0;
+        let position = - (MIDDLE - event.code as f32) * options.x_scale / 300.0;
         match event.etype {
             EventType::KeyDown => {
                 play_random_sound!(self.sounds_keydown, [position, 0.0, 1.0], options);


### PR DESCRIPTION
currently listens to events from `/dev/input/event0` or environment variable `MODELM_INPUT_DEVICE`

compiled and tested on arch linux 4.8.11-1